### PR TITLE
Removing "Courier" from iOS list

### DIFF
--- a/IosFonts.js
+++ b/IosFonts.js
@@ -114,7 +114,6 @@ export default class IosFonts extends Component{
         <Text style={{fontFamily: 'Copperplate'}}>Copperplate </Text>
         <Text style={{fontFamily: 'Copperplate-Bold'}}>Copperplate-Bold </Text>
         <Text style={{fontFamily: 'Copperplate-Light'}}>Copperplate-Light </Text>
-        <Text style={{fontFamily: 'Courier'}}>Courier </Text>
         <Text style={{fontFamily: 'Courier New'}}>Courier New </Text>
         <Text style={{fontFamily: 'Courier-Bold'}}>Courier-Bold </Text>
         <Text style={{fontFamily: 'Courier-BoldOblique'}}>Courier-BoldOblique </Text>


### PR DESCRIPTION
They removed it in iOS 15, according to a comment in this question: https://stackoverflow.com/q/69653718/368864 (I also confirmed it using an actual phone).